### PR TITLE
Activate critical state when battery is less than or equal

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,13 +21,13 @@ export default definePlugin((serverApi: ServerAPI) => {
   // percentage check loop
   SteamClient.System.RegisterForBatteryStateChanges((batteryState: BatteryState)=> {
     let batteryPercent = Math.round(batteryState.flLevel * 100)
-    if (!criticalNotifiedState && batteryPercent < Settings.criticalLevel ) {
+    if (!criticalNotifiedState && batteryPercent <= Settings.criticalLevel ) {
       console.debug(`[AutoSuspend] Critical threshold triggered, current state: warnNotifiedState:${warnNotifiedState}, criticalNotifiedState:${criticalNotifiedState}, warnThreshold:${Settings.warningLevel}, critThreshold:${Settings.criticalLevel}, battPercent:${batteryPercent}, battRaw:${batteryState.flLevel}`)
       console.debug(batteryState)
       SteamUtils.notify("AutoSuspend", "Critical limit exceeded, suspending device", Settings.notificationEnabled, Settings.soundEnabled, 5000)
       setTimeout(() => {SteamUtils.suspend();}, 5500)
       criticalNotifiedState = true
-    } else if (!warnNotifiedState && batteryPercent < Settings.warningLevel && Settings.warningLevel > Settings.criticalLevel && !criticalNotifiedState) {
+    } else if (!warnNotifiedState && batteryPercent <= Settings.warningLevel && Settings.warningLevel > Settings.criticalLevel && !criticalNotifiedState) {
       console.debug(`[AutoSuspend] Warning threshold triggered, current state: warnNotifiedState:${warnNotifiedState}, criticalNotifiedState:${criticalNotifiedState}, warnThreshold:${Settings.warningLevel}, critThreshold:${Settings.criticalLevel}, battPercent:${batteryPercent}, battRaw:${batteryState.flLevel}`)
       console.debug(batteryState)
       SteamUtils.notify("AutoSuspend", "Warning limit exceeded")


### PR DESCRIPTION
At the current moment, the deck will be suspended when the battery is less than the threshold. Instead of checking whether the battery is less than the target, we should check whether it's less than or equal to.

I believe this would make more sense, as the slider in the settings for AutoSuspend displays that the critical threshold might be 5%, leading the user to expect their deck to be suspended at 5% battery. Instead, it will suspend at 4%, which might lead some users into thinking that the plugin didn't work.